### PR TITLE
Allow someone to proxy full Conda repo with one Proxy

### DIFF
--- a/src/main/java/org/sonatype/nexus/plugins/conda/internal/CondaRecipeSupport.groovy
+++ b/src/main/java/org/sonatype/nexus/plugins/conda/internal/CondaRecipeSupport.groovy
@@ -115,35 +115,35 @@ abstract class CondaRecipeSupport
   //public static final String filenameIndexHtml...
 
   static Matcher rootChannelIndexHtmlMatcher() {
-    buildTokenMatcherForPatternAndAssetKind('/index.html', AssetKind.CHANNEL_INDEX_HTML, GET, HEAD)
+    buildTokenMatcherForPatternAndAssetKind('/{path:.+}/index.html', AssetKind.CHANNEL_INDEX_HTML, GET, HEAD)
   }
 
   static Matcher rootChannelDataJsonMatcher() {
-    buildTokenMatcherForPatternAndAssetKind('/channeldata.json', AssetKind.CHANNEL_DATA_JSON, GET, HEAD)
+    buildTokenMatcherForPatternAndAssetKind('/{path:.+}/channeldata.json', AssetKind.CHANNEL_DATA_JSON, GET, HEAD)
   }
 
   static Matcher rootChannelRssXmlMatcher() {
-    buildTokenMatcherForPatternAndAssetKind('/rss.xml', AssetKind.CHANNEL_RSS_XML, GET, HEAD)
+    buildTokenMatcherForPatternAndAssetKind('/{path:.+}/rss.xml', AssetKind.CHANNEL_RSS_XML, GET, HEAD)
   }
 
   static Matcher archIndexHtmlMatcher() {
-    buildTokenMatcherForPatternAndAssetKind('/{arch:.+}/index.html', AssetKind.ARCH_INDEX_HTML, GET, HEAD)
+    buildTokenMatcherForPatternAndAssetKind('/{path:.+}/{arch:.+}/index.html', AssetKind.ARCH_INDEX_HTML, GET, HEAD)
   }
 
   static Matcher archRepodataJsonMatcher() {
-    buildTokenMatcherForPatternAndAssetKind('/{arch:.+}/repodata.json', AssetKind.ARCH_REPODATA_JSON, GET, HEAD)
+    buildTokenMatcherForPatternAndAssetKind('/{path:.+}/{arch:.+}/repodata.json', AssetKind.ARCH_REPODATA_JSON, GET, HEAD)
   }
 
   static Matcher archRepodataJsonBz2Matcher() {
-    buildTokenMatcherForPatternAndAssetKind('/{arch:.+}/repodata.json.bz2', AssetKind.ARCH_REPODATA_JSON_BZ2, GET, HEAD)
+    buildTokenMatcherForPatternAndAssetKind('/{path:.+}/{arch:.+}/repodata.json.bz2', AssetKind.ARCH_REPODATA_JSON_BZ2, GET, HEAD)
   }
 
   static Matcher archRepodata2JsonMatcher() {
-    buildTokenMatcherForPatternAndAssetKind('/{arch:.+}/repodata2.json', AssetKind.ARCH_REPODATA2_JSON, GET, HEAD)
+    buildTokenMatcherForPatternAndAssetKind('/{path:.+}/{arch:.+}/repodata2.json', AssetKind.ARCH_REPODATA2_JSON, GET, HEAD)
   }
 
   static Matcher archCondaPackageMatcher() {
-    buildTokenMatcherForPatternAndAssetKind('/{arch:.+}/{name:.+}-{version:.+}-{build:.+}.tar.bz2', AssetKind.ARCH_CONDA_PACKAGE, GET, HEAD)
+    buildTokenMatcherForPatternAndAssetKind('/{path:.+}/{arch:.+}/{name:.+}-{version:.+}-{build:.+}.tar.bz2', AssetKind.ARCH_CONDA_PACKAGE, GET, HEAD)
   }
 
   static Matcher buildTokenMatcherForPatternAndAssetKind(final String pattern,

--- a/src/main/java/org/sonatype/nexus/plugins/conda/internal/proxy/CondaProxyFacetImpl.java
+++ b/src/main/java/org/sonatype/nexus/plugins/conda/internal/proxy/CondaProxyFacetImpl.java
@@ -77,11 +77,12 @@ public class CondaProxyFacetImpl
     TokenMatcher.State matcherState = condaPathUtils.matcherState(context);
     switch (assetKind) {
       case CHANNEL_INDEX_HTML:
-        return getAsset("/index.html");
+        return getAsset(condaPathUtils.buildAssetPath(matcherState, CondaPathUtils.INDEX_HTML));
+        // return getAsset("/index.html");
       case CHANNEL_DATA_JSON:
-        return getAsset("/channeldata.json");
+        return getAsset(condaPathUtils.buildAssetPath(matcherState, CondaPathUtils.CHANNELDATA_JSON));
       case CHANNEL_RSS_XML:
-        return getAsset("/rss.xml");
+        return getAsset(condaPathUtils.buildAssetPath(matcherState, CondaPathUtils.RSS_XML));
       case ARCH_INDEX_HTML:
         return getAsset(condaPathUtils.buildArchAssetPath(matcherState, "index.html"));
       case ARCH_REPODATA_JSON:
@@ -116,15 +117,15 @@ public class CondaProxyFacetImpl
       case CHANNEL_INDEX_HTML:
         return putMetadata(content,
             assetKind,
-            "/index.html");
+            condaPathUtils.buildAssetPath(matcherState, CondaPathUtils.INDEX_HTML));
       case CHANNEL_DATA_JSON:
         return putMetadata(content,
             assetKind,
-            "/channeldata.json");
+            condaPathUtils.buildAssetPath(matcherState, CondaPathUtils.CHANNELDATA_JSON));
       case CHANNEL_RSS_XML:
         return putMetadata(content,
             assetKind,
-            "/rss.xml");
+            condaPathUtils.buildAssetPath(matcherState, CondaPathUtils.RSS_XML));
       case ARCH_INDEX_HTML:
         return putMetadata(content,
             assetKind,

--- a/src/main/java/org/sonatype/nexus/plugins/conda/internal/util/CondaPathUtils.java
+++ b/src/main/java/org/sonatype/nexus/plugins/conda/internal/util/CondaPathUtils.java
@@ -28,6 +28,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @Singleton
 public class CondaPathUtils
 {
+  public static final String RSS_XML = "rss.xml";
+
+  public static final String INDEX_HTML = "index.html";
+
+  public static final String CHANNELDATA_JSON = "channeldata.json";
+
   public TokenMatcher.State matcherState(final Context context) {
     return context.getAttributes().require(TokenMatcher.State.class);
   }
@@ -39,6 +45,8 @@ public class CondaPathUtils
   public String name(final TokenMatcher.State state) {
     return match(state, "name");
   }
+
+  public String path(final TokenMatcher.State state) { return match(state, "path"); }
 
   public String version(final TokenMatcher.State state) {
     return match(state, "version");
@@ -55,11 +63,15 @@ public class CondaPathUtils
     return result;
   }
 
+  public String buildAssetPath(final State matcherState, final String assetName) {
+    return String.format("/%s/%s", path(matcherState), assetName);
+  }
+
   public String buildArchAssetPath(final State matcherState, final String assetName) {
-    return String.format("/%s/%s", arch(matcherState), assetName);
+    return String.format("/%s/%s/%s", path(matcherState), arch(matcherState), assetName);
   }
 
   public String buildCondaPackagePath(final State matcherState) {
-    return String.format("/%s/%s-%s-%s.tar.bz2", arch(matcherState), name(matcherState), version(matcherState), build(matcherState));
+    return String.format("/%s/%s/%s-%s-%s.tar.bz2", path(matcherState), arch(matcherState), name(matcherState), version(matcherState), build(matcherState));
   }
 }


### PR DESCRIPTION
A lil POC to see if it's easier to proxy using one repo, versus setting one up per channel

This pull request makes the following changes:
* Route changes to accomodate new `path`
* Helper methods to build paths

* Static strings to prevent typos (fat finger avoider)

![fingersyouhaveusedtodial](https://user-images.githubusercontent.com/5544326/55688655-57043180-5927-11e9-9f61-77db4d7a5f7d.png)

I haven't adjusted docs yet but with this you'd do:

* new proxy (`conda-proxy`) with URL: `https://repo.continuum.io/pkgs/`
* `conda install -c http://localhost:8081/repository/conda-proxy/main numpy`
 
Seems to check out using it, you can switch channels by appending the `free`, etc... channel name to the -c command. Assumedly you could also set all your individual channels in Conda too (did not test that).

Did this based on watching @hosenblad setup Conda for someone!

cc @DarthHater @bhamail
